### PR TITLE
Update PS-QSYS.psm1

### DIFF
--- a/PS-QSYS.psm1
+++ b/PS-QSYS.psm1
@@ -287,7 +287,7 @@ LLDPPortNumber :
 #>
 
     param([Parameter(mandatory)] [QSYS_Session] $Session)
-    _INT_GetNetConfig -Session $core | Select -ExpandProperty interfaces | Select -Property `
+    _INT_GetNetConfig -Session $Session | Select -ExpandProperty interfaces | Select -Property `
         @{ Name = 'Name'; Expression = {$_.name} },
         @{ Name = 'Mode'; Expression = {$_.mode} },
         @{ Name = 'IPAddress'; Expression = {$_.ipAddress} },


### PR DESCRIPTION
Line 290
replaced $core with $Session.

$core was null and not allowing the command. See error below:

> _INT_GetNetConfig : Cannot bind argument to parameter 'Session' because it is null.
> At C:\Program Files\WindowsPowerShell\Modules\PS-Qsys\0.1.0\PS-QSYS.psm1:290 char:32
> +     _INT_GetNetConfig -Session $core | Select -ExpandProperty interfa ...
> +                                ~~~~~
>     + CategoryInfo          : InvalidData: (:) [_INT_GetNetConfig], ParameterBindingValidationException
>     + FullyQualifiedErrorId : ParameterArgumentValidationErrorNullNotAllowed,_INT_GetNetConfig
>  

After changing to $Session, cmdlet started working.